### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/U_SENSOR/keywords.txt
+++ b/U_SENSOR/keywords.txt
@@ -1,36 +1,36 @@
  ######################################################
 ##                    DEFINES                         ##
  ######################################################
- 
-IN_RAW 			LITERAL1
-IN_MM 			LITERAL1
-IN_CM 			LITERAL1
-IN_DM 			LITERAL1
-IN_M 			LITERAL1
-IN_INCH 		LITERAL1
-IN_FEET 		LITERAL1
-IN_YARD 		LITERAL1
-U_SENSOR		LITERAL1
+
+IN_RAW	LITERAL1
+IN_MM	LITERAL1
+IN_CM	LITERAL1
+IN_DM	LITERAL1
+IN_M	LITERAL1
+IN_INCH	LITERAL1
+IN_FEET	LITERAL1
+IN_YARD	LITERAL1
+U_SENSOR	LITERAL1
 
  ######################################################
 ##                EXPERIMENTAL CONSTS                 ##
  ######################################################
 
-SOUND_SPEED_CM 		LITERAL1
-NO_DELAY 		LITERAL1
-DEF_DELAY 		LITERAL1
-MAX_RANGE_CM 		LITERAL1
-MIN_RANGE_CM 		LITERAL1
+SOUND_SPEED_CM	LITERAL1
+NO_DELAY	LITERAL1
+DEF_DELAY	LITERAL1
+MAX_RANGE_CM	LITERAL1
+MIN_RANGE_CM	LITERAL1
 
  ######################################################
 ##                FUCTION & CLASSES                   ##
  ######################################################
 
-USensor 		KEYWORD1
-getDis 			KEYWORD2
-getDisC 		KEYWORD2
-getDisD 		KEYWORD2
-getTrigPin 		KEYWORD2
-getEchoPin 		KEYWORD2
-setPins 		KEYWORD2
-isEnable		KEYWORD2
+USensor	KEYWORD1
+getDis	KEYWORD2
+getDisC	KEYWORD2
+getDisD	KEYWORD2
+getTrigPin	KEYWORD2
+getEchoPin	KEYWORD2
+setPins	KEYWORD2
+isEnable	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords